### PR TITLE
Change config to generic naming

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,7 @@
 Config = {}
 
-Config.PoliceVehicle = {
+-- Model name of vehicles that won't get fined
+Config.ExemptVehicle = {
     'police',
     'police2',
     'police3'


### PR DESCRIPTION
Was Police before, but cities have all sorts of jobs so better to just name it exempt.